### PR TITLE
Entity prop check

### DIFF
--- a/scripting/stringpool_fix.sp
+++ b/scripting/stringpool_fix.sp
@@ -11,5 +11,6 @@ public Plugin myinfo =
 
 public void OnEntityCreated(int entity, const char[] classname)
 {
-    SetEntProp(entity, Prop_Data, "m_bForcePurgeFixedupStrings", true);
+    if( HasEntProp(entity, Prop_Data, "m_bForcePurgeFixedupStrings") )
+        SetEntProp(entity, Prop_Data, "m_bForcePurgeFixedupStrings", true);
 }


### PR DESCRIPTION
Preventing "Exception reported: Property "m_bForcePurgeFixedupStrings" not found (entity 0/worldspawn)" errors.